### PR TITLE
cyanite-delete does not handle multiple cass nodes (#3)

### DIFF
--- a/cyanite/Config.py
+++ b/cyanite/Config.py
@@ -17,10 +17,16 @@ class Config():
         self.timewindow = 86400 * 3
 
     def cluster(self):
+        casshosts = []
         if 'store' in self.config:
             if 'cluster' in self.config['store']:
-                return self.config['store']['cluster']
-        return 'localhost'
+                if isinstance(self.config['store']['cluster'], basestring):
+                    casshosts.append(self.config['store']['cluster'])
+                    return casshosts
+                for host in self.config['store']['cluster']:
+                    casshosts.append(host)
+                return casshosts
+        return ['localhost']
 
     def keyspace(self):
         if 'store' in self.config:

--- a/cyanite/CyaniteCassandra.py
+++ b/cyanite/CyaniteCassandra.py
@@ -9,7 +9,7 @@ class CyaniteCassandra():
 
     def __init__(self, config):
         self.config = config
-        self.cluster = Cluster([config.cluster()])
+        self.cluster = Cluster(config.cluster())
         self.session = self.cluster.connect(config.keyspace())
         self.deletequery = self.session.prepare(
             """


### PR DESCRIPTION
- Change config.cluster() to return a list() instead of a string
- Pass the list to Cassandra.Cluster(), instead of forming it in the
  call.
