### PR TITLE
Support deleting paths from old versions of cyanite

### DIFF
--- a/cyanite_utils/Config.py
+++ b/cyanite_utils/Config.py
@@ -107,7 +107,7 @@ class Config():
     def espathindex(self):
         if 'index' in self.config:
             if 'use' in self.config['index']:
-                if self.config['index']['use'] == "io.cyanite.es_path/es-rest":
+                if self.config['index']['use'] == "io.cyanite.es_path/es-rest" or self.config['index']['use'] == "org.spootnik.cyanite.es_path/es-rest":
                     return True
         return False
 


### PR DESCRIPTION
In b593fac79009b901a4169958850926db0d6645af the namespace changed
from org.spootnik.cyanite to io.cyanite
