### PR TITLE
Change exception variable syntax

### DIFF
--- a/cyanite_utils/CyanitePaths.py
+++ b/cyanite_utils/CyanitePaths.py
@@ -62,7 +62,7 @@ class CyanitePaths():
         req.get_method = lambda: 'DELETE'
         try:
             response = urllib2.urlopen(req)
-        except urllib2.HTTPError, err:
+        except urllib2.HTTPError as err:
             if err.code == 404:
                 sys.stderr.write("path delete %s does not exist\n" % path)
                 sys.stderr.flush()


### PR DESCRIPTION
Compiling on Fedora 26 fails with the old syntax. Updated since
"Exception as var" is valid in both python version 2 and 3.